### PR TITLE
make SCFlyTools dependencies optional

### DIFF
--- a/ReadingOutputFromFLYonPIC_v2/requirements.txt
+++ b/ReadingOutputFromFLYonPIC_v2/requirements.txt
@@ -6,4 +6,4 @@ tqdm >= 4.66.1
 matplotlib >= 3.6.2
 matplotlib-label-lines >= 0.7.0
 
--r SCFlyTools/requirements.txt
+-r SCFlyTools/requirements.txt[SCFlyTools]


### PR DESCRIPTION
marks the SCFlyTools `requirements.txt` as optional, only to be installed if the user specifies it by `pip install -r requirements.txt[SCFlyTools]`