### PR TITLE
Decrease minimum numba version requirement to 0.58.1

### DIFF
--- a/ReadingOutputFromFLYonPIC_v2/requirements.txt
+++ b/ReadingOutputFromFLYonPIC_v2/requirements.txt
@@ -1,5 +1,5 @@
 numpy >= 1.23.3
-numba >=0.59.1
+numba >=0.58.1
 pydantic >= 2.3.0
 typeguard >= 4.1.3
 tqdm >= 4.66.1


### PR DESCRIPTION
Change because JURECA currently is on 0.58.1 